### PR TITLE
Add option to modify the query

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ protected function getStats(): array
     }
 ```
 
+### Modify the query
+You can use the `where` method to change the query. For example, to only show stats related to a specific user:
+
+```php
+protected function getStats(): array
+    {
+        return [
+            SimpleStat::make(Purchase::class)->where('user_id', auth()->id())->last30Days()->dailySum('earnings'),
+        ];
+    }
+```
+
 ## Testing
 
 ```bash

--- a/src/SimpleStat.php
+++ b/src/SimpleStat.php
@@ -55,6 +55,13 @@ class SimpleStat
         return $this;
     }
 
+    public function where($column, $operator = null, $value = null, $boolean = 'and'): self
+    {
+        $this->trend->builder->where($column, $operator, $value, $boolean);
+
+        return $this;
+    }
+
     public function last7Days(): self
     {
         return $this->lastDays(7);

--- a/tests/SimpleStatTest.php
+++ b/tests/SimpleStatTest.php
@@ -46,3 +46,21 @@ it('can create a widget with yearly count', function () {
     expect($widget->getDescription())->toEqual('Last 5 year(s)');
     expect($widget->getValue())->toBeString();
 });
+
+it('applies a where condition to the query', function () {
+    $simpleStat = SimpleStat::make(ExampleEvent::class)->where('score', '>', 50);
+
+    $query = $simpleStat->trend->builder->getQuery();
+
+    $whereClause = collect($query->wheres)->firstWhere('column', 'score');
+
+    expect($whereClause)->not->toBeNull();
+    expect($whereClause['operator'])->toEqual('>');
+    expect($whereClause['value'])->toEqual(50);
+
+    $results = $simpleStat->trend->builder->get();
+
+    foreach ($results as $result) {
+        expect($result->score)->toBeGreaterThan(50);
+    }
+});


### PR DESCRIPTION
I needed an option to add a where clause so I can show data related to the user.

Before:
```php
  protected function getStats(): array
  {
      $simpleStat = SimpleStat::make(MyModel::class);
  
      $simpleStat->trend = Trend::model(MyModel::class)->query(MyModel::where('user_id', auth()->id()));
  
      return [
          $simpleStat->last7Days()->dailyCount()->color('success'),
      ];
  }
```

Now:
```php
  protected function getStats(): array
  {
      return [
          SimpleStat::make(MyModel::class)->where('user_id', auth()->id())->last7Days()->dailyCount()->color('success'),
      ];
  }
```