### PR TITLE
Inline flowframe/laravel-trend and add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.4, 8.3]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     "require": {
         "php": "^8.3|^8.4",
         "filament/widgets": "^5.2",
-        "flowframe/laravel-trend": "^0.4.0",
         "illuminate/contracts": "^11.0||^12.0||^13.0",
         "spatie/laravel-package-tools": "^1.16"
     },

--- a/src/AggregateType.php
+++ b/src/AggregateType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Spatie\FilamentSimpleStats;
 
 enum AggregateType

--- a/src/SimpleStat.php
+++ b/src/SimpleStat.php
@@ -1,27 +1,29 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Spatie\FilamentSimpleStats;
 
 use Carbon\Carbon;
 use Filament\Widgets\StatsOverviewWidget\Stat;
-use Flowframe\Trend\Trend;
-use Flowframe\Trend\TrendValue;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Spatie\FilamentSimpleStats\Support\Trend;
+use Spatie\FilamentSimpleStats\Support\TrendValue;
 
 class SimpleStat
 {
     public Trend $trend;
 
-    protected ?string $label;
+    protected ?string $label = null;
 
-    protected ?string $description;
+    protected ?string $description = null;
 
     protected bool $overWriteDescription = false;
 
     public string $dateColumn = 'created_at';
 
-    public ?string $aggregateColumn;
+    public ?string $aggregateColumn = null;
 
     protected bool $showTrend = true;
 
@@ -70,7 +72,7 @@ class SimpleStat
         return $this;
     }
 
-    public function where($column, $operator = null, $value = null, $boolean = 'and'): self
+    public function where(mixed $column, mixed $operator = null, mixed $value = null, string $boolean = 'and'): self
     {
         $this->trend->builder->where($column, $operator, $value, $boolean);
 
@@ -207,9 +209,7 @@ class SimpleStat
         $this->periodGrouping = 'day';
         $this->aggregateColumn = $column;
 
-        $trendData = $this->trend->perDay()->sum($column);
-
-        return $this->buildSumStat($trendData);
+        return $this->buildSumStat($this->trend->perDay()->sum($column));
     }
 
     public function monthlySum(string $column): Stat
@@ -217,11 +217,10 @@ class SimpleStat
         $this->periodGrouping = 'month';
         $this->aggregateColumn = $column;
 
-        $trendData = $this->trend->perMonth()->sum($column);
-
-        return $this->buildSumStat($trendData);
+        return $this->buildSumStat($this->trend->perMonth()->sum($column));
     }
 
+    /** @param Collection<int, TrendValue> $trendData */
     protected function buildCountStat(Collection $trendData): Stat
     {
         $total = $trendData->sum('aggregate');
@@ -229,6 +228,7 @@ class SimpleStat
         return $this->buildStat($total, $trendData, AggregateType::Count);
     }
 
+    /** @param Collection<int, TrendValue> $trendData */
     protected function buildAverageStat(Collection $trendData): Stat
     {
         $total = $trendData->average('aggregate');
@@ -236,6 +236,7 @@ class SimpleStat
         return $this->buildStat($total ?? '', $trendData, AggregateType::Average);
     }
 
+    /** @param Collection<int, TrendValue> $trendData */
     protected function buildSumStat(Collection $trendData): Stat
     {
         $total = $trendData->sum('aggregate');
@@ -263,30 +264,11 @@ class SimpleStat
             default => $this->periodEnd,
         };
 
-        // Create a fresh Trend instance for the previous period
-        // We need to get a base query without the date range constraint
-        $baseModel = $this->model;
-        $previousTrend = Trend::model($baseModel)
-            ->dateColumn($this->dateColumn);
+        $previousTrend = Trend::model($this->model)
+            ->dateColumn($this->dateColumn)
+            ->between(start: $previousStart, end: $previousEnd);
 
-        // Apply any where clauses that were added via the where() method
-        // We do this by creating a new query and copying the wheres
-        $originalWheres = $this->trend->builder->getQuery()->wheres;
-        foreach ($originalWheres as $where) {
-            // Skip date-related where clauses from the between() method
-            if (isset($where['column']) && $where['column'] === $this->dateColumn) {
-                continue;
-            }
-            // For now, just rebuild the query with the same wheres
-            // This is a simplified approach - might need refinement for complex queries
-        }
-
-        $previousTrend->between(
-            start: $previousStart,
-            end: $previousEnd,
-        );
-
-        $previousData = match ($this->periodGrouping) {
+        $previousTrend = match ($this->periodGrouping) {
             'day' => $previousTrend->perDay(),
             'month' => $previousTrend->perMonth(),
             'year' => $previousTrend->perYear(),
@@ -294,11 +276,11 @@ class SimpleStat
         };
 
         $previousData = match ($aggregateType) {
-            AggregateType::Count => $previousData->count(),
-            AggregateType::Sum => $previousData->sum($this->aggregateColumn),
+            AggregateType::Count => $previousTrend->count(),
+            AggregateType::Sum => $previousTrend->sum($this->aggregateColumn),
             AggregateType::Average => isset($this->aggregateColumn)
-                ? $previousData->average($this->aggregateColumn)
-                : $previousData->count(),
+                ? $previousTrend->average($this->aggregateColumn)
+                : $previousTrend->count(),
         };
 
         return match ($aggregateType) {
@@ -307,7 +289,8 @@ class SimpleStat
         };
     }
 
-    protected function buildStat(int|float $faceValue, Collection $chartValues, AggregateType $aggregateType): Stat
+    /** @param Collection<int, TrendValue> $chartValues */
+    protected function buildStat(int|float|string $faceValue, Collection $chartValues, AggregateType $aggregateType): Stat
     {
         $stat = Stat::make($this->buildLabel($aggregateType), $this->formatFaceValue($faceValue))
             ->chart($chartValues->map(fn (TrendValue $trend) => $trend->aggregate)->toArray())
@@ -343,7 +326,7 @@ class SimpleStat
         $description = ($percentageChange > 0 ? '+' : '-').$formattedPercentage;
 
         if ($this->description) {
-            $description = $this->description.' ('.$description.')';
+            $description = "{$this->description} ({$description})";
         }
 
         return $stat
@@ -352,8 +335,12 @@ class SimpleStat
             ->color($color);
     }
 
-    protected function formatFaceValue(int|float $total): string
+    protected function formatFaceValue(int|float|string $total): string
     {
+        if (is_string($total)) {
+            return $total;
+        }
+
         if ($total > 1000) {
             return number_format($total / 1000, 2).'k';
         }
@@ -363,7 +350,7 @@ class SimpleStat
 
     protected function buildLabel(AggregateType $aggregateType): string
     {
-        if (isset($this->label)) {
+        if ($this->label !== null) {
             return $this->label;
         }
 
@@ -389,7 +376,7 @@ class SimpleStat
 
     protected function getEntityName(): string
     {
-        if (! isset($this->aggregateColumn)) {
+        if ($this->aggregateColumn === null) {
             return Str::plural(Str::title(Str::snake(class_basename($this->model), ' ')));
         }
 

--- a/src/Support/Trend.php
+++ b/src/Support/Trend.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\FilamentSimpleStats\Support;
+
+use Carbon\CarbonInterface;
+use Carbon\CarbonPeriod;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+
+/** @internal */
+final class Trend
+{
+    public CarbonInterface $start;
+
+    public CarbonInterface $end;
+
+    private string $interval;
+
+    private string $dateColumn = 'created_at';
+
+    public function __construct(public Builder $builder) {}
+
+    public static function model(string $model): self
+    {
+        return new self($model::query());
+    }
+
+    public function dateColumn(string $column): self
+    {
+        $this->dateColumn = $column;
+
+        return $this;
+    }
+
+    public function between(CarbonInterface $start, CarbonInterface $end): self
+    {
+        $this->start = $start;
+        $this->end = $end;
+
+        return $this;
+    }
+
+    public function perDay(): self
+    {
+        $this->interval = 'day';
+
+        return $this;
+    }
+
+    public function perMonth(): self
+    {
+        $this->interval = 'month';
+
+        return $this;
+    }
+
+    public function perYear(): self
+    {
+        $this->interval = 'year';
+
+        return $this;
+    }
+
+    /** @return Collection<int, TrendValue> */
+    public function count(string $column = '*'): Collection
+    {
+        return $this->aggregate($column, 'count');
+    }
+
+    /** @return Collection<int, TrendValue> */
+    public function sum(string $column): Collection
+    {
+        return $this->aggregate($column, 'sum');
+    }
+
+    /** @return Collection<int, TrendValue> */
+    public function average(string $column): Collection
+    {
+        return $this->aggregate($column, 'avg');
+    }
+
+    /** @return Collection<int, TrendValue> */
+    private function aggregate(string $column, string $function): Collection
+    {
+        $dateAlias = 'date';
+
+        $values = $this->builder
+            ->toBase()
+            ->selectRaw("{$this->formatDateForDriver()} as {$dateAlias}, {$function}({$column}) as aggregate")
+            ->whereBetween($this->dateColumn, [$this->start, $this->end])
+            ->groupBy($dateAlias)
+            ->orderBy($dateAlias)
+            ->get();
+
+        return $this->fillGaps($values, $dateAlias);
+    }
+
+    /** @return Collection<int, TrendValue> */
+    private function fillGaps(Collection $values, string $dateAlias): Collection
+    {
+        $values = $values->map(fn ($value) => new TrendValue(
+            date: $value->{$dateAlias},
+            aggregate: $value->aggregate,
+        ));
+
+        $placeholders = collect(CarbonPeriod::between($this->start, $this->end)->interval("1 {$this->interval}"))
+            ->map(fn (CarbonInterface $date) => new TrendValue(
+                date: $date->format($this->carbonDateFormat()),
+                aggregate: 0,
+            ));
+
+        return $values
+            ->merge($placeholders)
+            ->unique('date')
+            ->sort()
+            ->flatten();
+    }
+
+    private function formatDateForDriver(): string
+    {
+        $driver = $this->builder->getConnection()->getDriverName();
+
+        return match ($driver) {
+            'mysql', 'mariadb' => $this->mysqlFormat(),
+            'pgsql' => $this->pgsqlFormat(),
+            'sqlite' => $this->sqliteFormat(),
+            default => throw new InvalidArgumentException("Unsupported database driver: {$driver}"),
+        };
+    }
+
+    private function mysqlFormat(): string
+    {
+        $format = match ($this->interval) {
+            'day' => '%Y-%m-%d',
+            'month' => '%Y-%m',
+            'year' => '%Y',
+        };
+
+        return "date_format({$this->dateColumn}, '{$format}')";
+    }
+
+    private function pgsqlFormat(): string
+    {
+        $format = match ($this->interval) {
+            'day' => 'YYYY-MM-DD',
+            'month' => 'YYYY-MM',
+            'year' => 'YYYY',
+        };
+
+        return "to_char(\"{$this->dateColumn}\", '{$format}')";
+    }
+
+    private function sqliteFormat(): string
+    {
+        $format = match ($this->interval) {
+            'day' => '%Y-%m-%d',
+            'month' => '%Y-%m',
+            'year' => '%Y',
+        };
+
+        return "strftime('{$format}', {$this->dateColumn})";
+    }
+
+    private function carbonDateFormat(): string
+    {
+        return match ($this->interval) {
+            'day' => 'Y-m-d',
+            'month' => 'Y-m',
+            'year' => 'Y',
+        };
+    }
+}

--- a/src/Support/Trend.php
+++ b/src/Support/Trend.php
@@ -6,6 +6,7 @@ namespace Spatie\FilamentSimpleStats\Support;
 
 use Carbon\CarbonInterface;
 use Carbon\CarbonPeriod;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
@@ -121,7 +122,7 @@ final class Trend
 
     private function formatDateForDriver(): string
     {
-        /** @var \Illuminate\Database\Connection $connection */
+        /** @var Connection $connection */
         $connection = $this->builder->getConnection();
         $driver = $connection->getDriverName();
 

--- a/src/Support/Trend.php
+++ b/src/Support/Trend.php
@@ -121,7 +121,9 @@ final class Trend
 
     private function formatDateForDriver(): string
     {
-        $driver = $this->builder->getConnection()->getDriverName();
+        /** @var \Illuminate\Database\Connection $connection */
+        $connection = $this->builder->getConnection();
+        $driver = $connection->getDriverName();
 
         return match ($driver) {
             'mysql', 'mariadb' => $this->mysqlFormat(),
@@ -137,6 +139,7 @@ final class Trend
             'day' => '%Y-%m-%d',
             'month' => '%Y-%m',
             'year' => '%Y',
+            default => throw new InvalidArgumentException("Unsupported interval: {$this->interval}"),
         };
 
         return "date_format({$this->dateColumn}, '{$format}')";
@@ -148,6 +151,7 @@ final class Trend
             'day' => 'YYYY-MM-DD',
             'month' => 'YYYY-MM',
             'year' => 'YYYY',
+            default => throw new InvalidArgumentException("Unsupported interval: {$this->interval}"),
         };
 
         return "to_char(\"{$this->dateColumn}\", '{$format}')";
@@ -159,6 +163,7 @@ final class Trend
             'day' => '%Y-%m-%d',
             'month' => '%Y-%m',
             'year' => '%Y',
+            default => throw new InvalidArgumentException("Unsupported interval: {$this->interval}"),
         };
 
         return "strftime('{$format}', {$this->dateColumn})";
@@ -170,6 +175,7 @@ final class Trend
             'day' => 'Y-m-d',
             'month' => 'Y-m',
             'year' => 'Y',
+            default => throw new InvalidArgumentException("Unsupported interval: {$this->interval}"),
         };
     }
 }

--- a/src/Support/TrendValue.php
+++ b/src/Support/TrendValue.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\FilamentSimpleStats\Support;
+
+/** @internal */
+final readonly class TrendValue
+{
+    public function __construct(
+        public string $date,
+        public int|float $aggregate,
+    ) {}
+}


### PR DESCRIPTION
## Summary
- Inlines the `flowframe/laravel-trend` dependency (which doesn't support Laravel 13 yet) into `src/Support/Trend.php` and `src/Support/TrendValue.php`
- Removes `flowframe/laravel-trend` from composer.json
- Adds Laravel 13 back to the CI test matrix
- Cleans up code with strict types and modern PHP patterns